### PR TITLE
Prevent crash in QML

### DIFF
--- a/inst/qml/common/MixedModelsModel.qml
+++ b/inst/qml/common/MixedModelsModel.qml
@@ -59,7 +59,7 @@ Section
 			{
 				Layout.preferredWidth:	randomEffetcs.width
 				Label { text: qsTr("Random slopes by %1").arg(rowValue); Layout.preferredWidth: parent.width / 2 }
-				CheckBox { label: qsTr("Correlations"); name: "correlations"; checked: true; Layout.preferredWidth: parent.width / 2 }
+				CheckBox { label: qsTr("Correlations"); name: "correlations"; checked: true }
 			}
 
 			VariablesList


### PR DESCRIPTION
By adding the preferredWidth on both element of RowLayout, QML crashes.
I try to reproduce with a simple example and will make an issue by Qt